### PR TITLE
feat(cache): Prepare for `ArtifactSpec` interoperability (Round 1)

### DIFF
--- a/crates/redesmyn/src/cache.rs
+++ b/crates/redesmyn/src/cache.rs
@@ -910,6 +910,7 @@ impl Cache {
         // TODO: Figure out how to accept a generic `impl Client` argument, e.g. wrapper struct over `Arc<dyn Client>`
         client: FsClient,
         load_model: Bound<'_, PyAny>,
+        spec: Option<Bound<'_, PyAny>>,
         max_size: Option<usize>,
         schedule: Option<Bound<'_, PyAny>>,
         interval: Option<Bound<'_, PyDelta>>,

--- a/py-redesmyn/redesmyn/artifacts.py
+++ b/py-redesmyn/redesmyn/artifacts.py
@@ -301,12 +301,14 @@ class CacheConfig(BaseModel, Generic[M]):
 
     client: FsClient
     """The client by which the cache will retrieve model artifacts."""
-    load_model: Callable[..., M]
+    load_model: Callable[..., M]  # TODO: Better argument typing
     """The method by which the cache will load the model artifact into the present application."""
     spec: Optional[Type[ArtifactSpec[M]]] = None
     """An `ArtifactSpec` describing the specification of the model artifacts to be used with the present cache."""
-    max_size: Optional[int] = None
+    max_size: Optional[int] = None  # TODO: Should default to actual default max size
     """The maximum number of models to be stored in the cache."""
+    pre_fetch_all: bool = True
+    """Whether to pre-fetch all available latest model parametrizations when the cache first starts."""
     schedule: Optional[Cron] = None
     """A cron schedule specifying the frequency of cache entry refreshes."""
     interval: Optional[timedelta] = None

--- a/py-redesmyn/redesmyn/artifacts.py
+++ b/py-redesmyn/redesmyn/artifacts.py
@@ -303,7 +303,7 @@ class CacheConfig(BaseModel, Generic[M]):
     """The client by which the cache will retrieve model artifacts."""
     load_model: Callable[..., M]
     """The method by which the cache will load the model artifact into the present application."""
-    spec: Type[ArtifactSpec[M]]
+    spec: Optional[Type[ArtifactSpec[M]]] = None
     """An `ArtifactSpec` describing the specification of the model artifacts to be used with the present cache."""
     max_size: Optional[int] = None
     """The maximum number of models to be stored in the cache."""

--- a/py-redesmyn/src/lib.rs
+++ b/py-redesmyn/src/lib.rs
@@ -102,7 +102,7 @@ impl PyServer {
         endpoint: &PyEndpoint,
         cache_config: Bound<'_, PyAny>,
     ) -> PyResult<()> {
-        let fs_client = cache_config.getattr("client")?.extract::<FsClient>()?;
+        let fs_client: FsClient = cache_config.getattr("client")?.extract::<FsClient>()?;
         let load_model: Py<_> = cache_config.getattr("load_model")?.clone().unbind();
         let schedule = cache_config.getattr("schedule").ok();
         let interval = cache_config
@@ -114,11 +114,12 @@ impl PyServer {
             })
             .ok();
         let max_size: Option<usize> = cache_config.getattr("max_size")?.extract().ok();
+        let pre_fetch_all: bool = cache_config.getattr("pre_fetch_all")?.extract()?;
         let cache = Cache::new(
             fs_client,
             max_size,
             validate_schedule(schedule, interval)?,
-            Some(true),
+            Some(pre_fetch_all),
             load_model,
         );
 


### PR DESCRIPTION
## What

The `spec: ArtifactSpec` parameter to `CacheConfig` should be optional for reasons described in that ticket. The ticket itself turns out to be superfluous because at the moment this parameter is not actually used in the Rust side of things, i.e. to validate request parameters (see https://github.com/davidagold/redesmyn/issues/43). 

However, in preparing for `ArtifactSpec` interoperability between the Rust and Python sides, I observed that the notion of an `ArtifactSpec` is used differently between the Rust `Cache` implementation and the Python validation design:
- In the `Cache` implementation, we use `ArtifactSpec` to refer to an "instantiated" spec, i.e. one that has both keys (field/parameter names) and values (requested parameter variants).
- On the other hand, the Python API design has revolved primarily around the validation side of things, in which an `ArtifactSpec` is the class itself and hence can be used to validate particular model instances.

These differences do not have anything to do with the languages per se, but rather the different stages in endpoint specification/request handling that the respective implementations attend to. However, it does mean that, once we pass the Python `ArtifactSpec` _class_ to the Rust-side `Cache`, we will need to be able to distinguish on the Rust side between `ArtifactSpec` classes and instances.

## What else

The above came to light as I attempted to implement default `ArtifactSpec` behavior based on the `Cache` path template fields, which quickly ran into the difficulty that I was attempting to create a construct similar to the class sense of a spec. Since Rust lacks reflection and runtime metaprogramming, this is not appropriate and requires support out of the scope of the associated ticket.  However, I will leave the stub a `Pydantic` trait to facilitate working with `Pydantic` models.


Resolves https://github.com/davidagold/redesmyn/issues/69.