### PR TITLE
feat(artifacts): Use `ArtifactSpec` to validate request parameters

### DIFF
--- a/crates/redesmyn/src/cache.rs
+++ b/crates/redesmyn/src/cache.rs
@@ -44,8 +44,9 @@ use tracing::{error, info, info_span, instrument, warn};
 
 const DEFAULT_CACHE_SIZE: usize = 128;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum Schedule {
+    #[default]
     Off,
     Cron(cron::Schedule),
     Interval(Duration),
@@ -64,12 +65,6 @@ impl Schedule {
             (Schedule::Off, _) => UpdateTime::Never,
         };
         next_update.into()
-    }
-}
-
-impl Default for Schedule {
-    fn default() -> Self {
-        Schedule::Cron(cron::Schedule::from_str("0 0 0 * * *").unwrap())
     }
 }
 

--- a/crates/redesmyn/src/cache.rs
+++ b/crates/redesmyn/src/cache.rs
@@ -1,6 +1,6 @@
 use crate::{
-    artifacts::{ArtifactSpec, BoxedSpec, FetchAs, Uri},
-    common::{build_runtime, consume_and_log_err, TOKIO_RUNTIME},
+    artifacts::{ArtifactSpec, BoxedSpec, FetchAs, Pydantic, Uri},
+    common::{__Str__, build_runtime, consume_and_log_err, TOKIO_RUNTIME},
     do_in,
     error::{ServiceError, ServiceResult},
 };
@@ -105,13 +105,6 @@ impl std::fmt::Display for UpdateTime {
 impl From<DateTime<Utc>> for UpdateTime {
     fn from(dt: DateTime<Utc>) -> Self {
         Self::DateTime(dt)
-    }
-}
-
-fn __str__(obj: &Py<PyAny>) -> String {
-    match Python::with_gil(|py| obj.call_method0(py, "__str__")?.extract::<String>(py)) {
-        Ok(model_str) => model_str,
-        Err(_) => "<Failure calling `__str__` for Python object>".into(),
     }
 }
 
@@ -412,20 +405,20 @@ impl std::fmt::Display for ModelEntry {
             InUse(_, None) => "<In use, (never updated -- this shouldn't happen!)>".to_string(),
             InUse(_, Some(last_updated)) => format!("<In use, (last updated {})>", last_updated),
             Refreshing(Some(model), Some(last_updated)) => {
-                format!("<Refreshing, {}>, (last updated {})", __str__(model), last_updated)
+                format!("<Refreshing, {}>, (last updated {})", model.__str__(), last_updated)
             }
             Refreshing(None, None) => "<Refreshing, no model, (never updated)>".into(),
             Refreshing(Some(model), None) => {
-                format!("<Refreshing, {}, (never updated)>", __str__(model))
+                format!("<Refreshing, {}, (never updated)>", model.__str__())
             }
             Refreshing(None, Some(last_updated)) => {
                 format!("<Refreshing, no model, (last updated {} -- what??)>", last_updated)
             }
             Ready(model, Some(last_updated)) => {
-                format!("<Ready, {}, (last updated {})>", __str__(model), last_updated)
+                format!("<Ready, {}, (last updated {})>", model.__str__(), last_updated)
             }
             Ready(model, None) => {
-                format!("<Ready, {}, (never updated -- this shouldn't happen!)>", __str__(model))
+                format!("<Ready, {}, (never updated -- this shouldn't happen!)>", model.__str__())
             }
             Empty => "<Empty>".to_string(),
         };
@@ -481,6 +474,7 @@ pub struct Cache {
     tx: OnceCell<Arc<mpsc::Sender<Command>>>,
     task: OnceCell<JoinHandle<Result<(), CacheError>>>,
     load_model: Py<PyAny>,
+    artifact_spec: Option<Arc<dyn Pydantic>>,
 }
 
 impl std::fmt::Display for Cache {
@@ -492,6 +486,7 @@ impl std::fmt::Display for Cache {
 #[derive(Clone)]
 pub struct CacheHandle {
     tx: Arc<mpsc::Sender<Command>>,
+    artifact_spec: Option<Arc<dyn Pydantic>>,
 }
 
 impl CacheHandle {
@@ -505,6 +500,13 @@ impl CacheHandle {
             }
             Ok(Ok(model)) => Ok(model),
         }
+    }
+
+    pub fn validate(
+        &self,
+        artifact_params: &IndexMap<String, String>,
+    ) -> Option<CacheResult<Py<PyAny>>> {
+        Some(self.artifact_spec.as_ref()?.validate(artifact_params).map_err(CacheError::from))
     }
 }
 
@@ -521,6 +523,7 @@ impl Cache {
         schedule: Option<Schedule>,
         pre_fetch_all: Option<bool>,
         load_model: Py<PyAny>,
+        artifact_spec: Option<Py<PyAny>>,
     ) -> Cache {
         Cache {
             client: Arc::from(client),
@@ -530,6 +533,7 @@ impl Cache {
             tx: OnceCell::<Arc<mpsc::Sender<Command>>>::default(),
             task: OnceCell::<JoinHandle<Result<(), CacheError>>>::default(),
             load_model,
+            artifact_spec: artifact_spec.map(|spec| -> Arc<dyn Pydantic> { Arc::new(spec) }),
         }
     }
 
@@ -558,7 +562,10 @@ impl Cache {
         let tx = self.tx.get().clone().ok_or_else(|| {
             CacheError::from("Cannot obtain handle for Cache that has not yet been started")
         })?;
-        Ok(CacheHandle { tx: tx.clone() })
+        Ok(CacheHandle {
+            tx: tx.clone(),
+            artifact_spec: self.artifact_spec.clone(),
+        })
     }
 
     #[instrument(skip_all)]
@@ -805,7 +812,7 @@ impl Cache {
         let model = Python::with_gil(|py| load_fn.call_bound(py, (data.into_py(py)?,), None));
         match (model, cache.pop(&key)) {
             (Ok(new_model), Some((taskflow, model_entry))) => {
-                info!("Successfully loaded model: `{}`", __str__(&new_model));
+                info!("Successfully loaded model: `{}`", &new_model.__str__());
                 // We expect `model_entry` to be in the `Refreshing` state
                 match model_entry {
                     // We're trying to update a model for which a refresh has not been initiated
@@ -814,7 +821,7 @@ impl Cache {
                         old_model, key
                     ))),
                     ModelEntry::Refreshing(old_model, last_updated_prev) => {
-                        let new_model_str = __str__(&new_model);
+                        let new_model_str = &new_model.__str__();
                         let last_updated = Utc::now();
                         cache.put(
                             key.clone(),
@@ -915,15 +922,16 @@ impl Cache {
         schedule: Option<Bound<'_, PyAny>>,
         interval: Option<Bound<'_, PyDelta>>,
         pre_fetch_all: Option<bool>,
+        artifact_spec: Option<Bound<'_, PyAny>>,
     ) -> PyResult<Cache> {
-        let cache = Cache::new(
+        Ok(Cache::new(
             client,
             max_size,
             validate_schedule(schedule, interval)?,
             pre_fetch_all,
             load_model.unbind(),
-        );
-        Ok(cache)
+            artifact_spec.map(|obj| obj.unbind()),
+        ))
     }
 
     fn start(&self) -> PyResult<()> {

--- a/crates/redesmyn/src/predictions.rs
+++ b/crates/redesmyn/src/predictions.rs
@@ -393,8 +393,8 @@ where
 
     if endpoint_config.validate_artifact_params {
         if let Some(Err(err)) = service_handle.cache_handle.validate(&spec) {
-            // TODO: Should return 4xx
-            return HttpResponse::InternalServerError().body(err.to_string());
+            info!("Invalid request parameters: {}", err);
+            return HttpResponse::UnprocessableEntity().body(err.to_string());
         }
     };
     let (tx, rx) = oneshot::channel();

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> Result<(), ServiceError> {
         )),
         Some(true),
         load_model,
+        None,
     );
 
     let endpoint = BatchPredictor::<String, Schema>::builder()

--- a/py-redesmyn/redesmyn/py_redesmyn.pyi
+++ b/py-redesmyn/redesmyn/py_redesmyn.pyi
@@ -21,7 +21,8 @@ class PyEndpoint:
         path: str,
         handler: Callable,
         batch_max_delay_ms: int = 10,
-        batch_max_size: int = 32,
+        batch_max_size: int = 64,
+        validate_artifact_params: bool = False,
     ) -> "PyEndpoint": ...
 
 class PyServer:

--- a/py-redesmyn/redesmyn/service.py
+++ b/py-redesmyn/redesmyn/service.py
@@ -43,6 +43,7 @@ class Endpoint(Generic[M]):
         cache_config: CacheConfig[M],
         batch_max_delay_ms: int,
         batch_max_size: int,
+        validate_artifact_params: bool = False,
     ) -> None:
         self._handler = handler
         self._pyendpoint = PyEndpoint(
@@ -51,6 +52,7 @@ class Endpoint(Generic[M]):
             batch_max_delay_ms=batch_max_delay_ms,
             batch_max_size=batch_max_size,
             handler=handler,
+            validate_artifact_params=validate_artifact_params,
         )
         self._cache_config = cache_config
 
@@ -63,6 +65,7 @@ def endpoint(
     cache_config: CacheConfig[M],
     batch_max_delay_ms: int = 10,
     batch_max_size: int = 32,
+    validate_artifact_params: bool = False,
 ) -> Callable[[Callable[[M, pl.DataFrame], pl.DataFrame]], Endpoint]:
     def wrapper(handler: Callable[[M, pl.DataFrame], pl.DataFrame]) -> Endpoint:
         return Endpoint(
@@ -72,6 +75,7 @@ def endpoint(
             cache_config=cache_config,
             batch_max_delay_ms=batch_max_delay_ms,
             batch_max_size=batch_max_size,
+            validate_artifact_params=validate_artifact_params,
         )
 
     return wrapper

--- a/py-redesmyn/tests/test_logging.py
+++ b/py-redesmyn/tests/test_logging.py
@@ -68,7 +68,6 @@ async def predict_then_stop(server: Server, irises: pl.DataFrame):
 
 class TestLogging:
     async def _serve_and_predict(self, server: Server, irises: pl.DataFrame):
-        loop = asyncio.get_running_loop()
         async with asyncio.TaskGroup() as tg:
             tg.create_task(server.serve())
             tg.create_task(predict_then_stop(server, irises))

--- a/py-redesmyn/tests/test_server.py
+++ b/py-redesmyn/tests/test_server.py
@@ -1,0 +1,94 @@
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Callable, Coroutine, Dict, List, Optional
+from unittest import mock
+
+import aiohttp
+import mlflow
+import polars as pl
+import pytest
+from more_itertools import first
+from redesmyn import artifacts as afs
+from redesmyn.py_redesmyn import LogConfig
+from redesmyn.service import Server, endpoint
+from sklearn.utils.discovery import itemgetter
+
+from tests.fixtures.iris_model import get_handle
+
+PROJECT_DIR = Path(__file__).parent.parent
+
+
+@pytest.fixture()
+def irises() -> pl.DataFrame:
+    return pl.read_csv(PROJECT_DIR / "examples/iris/data/iris.csv")
+
+
+async def request_prediction(
+    session: aiohttp.ClientSession,
+    run_id: str,
+    data: Dict,
+    response_by_run_id: Dict[str, Dict],
+    callback: Optional[Callable[..., Coroutine]] = None,
+):
+    url = f"http://localhost:8080/predictions/{run_id}/000449a650df4e36844626e647d15664"
+    async with session.post(url, json=[json.dumps(data)]) as resp:
+        record = {"http_status_code": resp.status, "run_id": run_id, "body": await resp.text()}
+        response_by_run_id[run_id] = record
+
+    if callback:
+        await callback()
+
+
+async def serve_and_predict(
+    server: Server, irises: pl.DataFrame, response_by_run_id: Dict[str, Dict]
+):
+    field_names = [
+        "sepal_width",
+        "petal_length",
+        "petal_width",
+    ]
+    data = first(list(irises.iter_rows(named=True)))
+    print(data)
+    async with aiohttp.ClientSession() as session:
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(server.serve())
+            tg.create_task(
+                request_prediction(
+                    session=session,
+                    run_id="903683212157180428",
+                    data=data,
+                    response_by_run_id=response_by_run_id,
+                )
+            )
+            tg.create_task(
+                request_prediction(
+                    session=session,
+                    run_id="invalid_run_id",
+                    data=data,
+                    response_by_run_id=response_by_run_id,
+                    callback=server.stop,
+                )
+            )
+
+
+class TestServer:
+    @mock.patch.dict(os.environ, {"RUST_LOG": "info"})
+    def test_validates_artifact_params(self, irises: pl.DataFrame):
+        dir_logs = Path(__file__).parent / "logs"
+        dir_logs.mkdir(exist_ok=True)
+        with tempfile.NamedTemporaryFile(dir=dir_logs, delete=False) as f:
+            LogConfig(path=Path(f.name)).init()
+
+        server = Server()
+        server.register(get_handle(validate_artifact_params=True))
+        response_by_run_id = {}
+        coro = serve_and_predict(server=server, irises=irises, response_by_run_id=response_by_run_id)
+        asyncio.run(coro)
+        assert response_by_run_id["903683212157180428"]["http_status_code"] == 200
+        assert response_by_run_id["invalid_run_id"]["http_status_code"] == 422
+        assert response_by_run_id["invalid_run_id"]["body"].startswith(
+            "Python Error: ValidationError"
+        )


### PR DESCRIPTION
## What

Users can declare Pydantic artifact schemas with validation logic. Our intention with this feature is to enable users to validate request parameters using Pydantic. This PR uses an artifact spec, if provided, to validate model artifact parameters if the new `validate_artifact_params` `Endpoint` parameter is set to `True`.

We should consider whether we actually want `validate_artifact_params` to be available, or whether we should just assume that if you provide validation machinery then you want us to use it. (Perhaps we make `True` the default.)

Resolves #43 