### PR TITLE
test(server): Include test of server functionality under `FsClient` misconfiguration

### DIFF
--- a/py-redesmyn/tests/common.py
+++ b/py-redesmyn/tests/common.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
+import logging
 from pathlib import Path
-from typing import Callable, Coroutine, Dict, List, Optional
+from typing import Callable, Coroutine, Dict, List, Optional, Type
 
 import aiohttp
 import polars as pl
@@ -11,6 +12,27 @@ from redesmyn import service as svc
 DIR_TESTS = Path(__file__).parent
 DIR_PYREDESMYN = DIR_TESTS.parent
 DIR_PROJECT = DIR_PYREDESMYN.parent
+
+
+async def retry(
+    coro: Coroutine,
+    retryable: List[Type[Exception]],
+    exp_backoff_coef_ms: int = 1000,
+    max_num_attempts: int = 3,
+):
+    num_attempts = 0
+    while num_attempts <= max_num_attempts:
+        num_attempts += 1
+        try:
+            return await coro
+        except Exception as e:
+            if type(e) in retryable:
+                wait_ms = exp_backoff_coef_ms * 2 ** (num_attempts - 1)
+                num_attempts_remaining = max_num_attempts - num_attempts
+                logging.warn(f"Encountered exception {e} while trying {coro}")
+                await asyncio.sleep(wait_ms / 1000)
+            else:
+                raise e
 
 
 async def request_prediction(
@@ -35,6 +57,9 @@ async def serve_and_predict(
     async with aiohttp.ClientSession() as session, asyncio.TaskGroup() as server_tg:
         server_tg.create_task(server.serve())
         async with asyncio.TaskGroup() as inner_tg:
-            [inner_tg.create_task(t) for t in tasks(session=session, data=data)]
+            [
+                inner_tg.create_task(retry(t, retryable=[aiohttp.client.ClientConnectorError]))
+                for t in tasks(session=session, data=data)
+            ]
 
         server_tg.create_task(server.stop())

--- a/py-redesmyn/tests/common.py
+++ b/py-redesmyn/tests/common.py
@@ -1,5 +1,40 @@
+import asyncio
+import json
 from pathlib import Path
+from typing import Callable, Coroutine, Dict, List, Optional
+
+import aiohttp
+import polars as pl
+from more_itertools import first
+from redesmyn import service as svc
 
 DIR_TESTS = Path(__file__).parent
 DIR_PYREDESMYN = DIR_TESTS.parent
 DIR_PROJECT = DIR_PYREDESMYN.parent
+
+
+async def request_prediction(
+    session: aiohttp.ClientSession,
+    url: str,
+    data: Dict,
+    callback: Optional[Callable[..., Coroutine]] = None,
+):
+    resp = await session.post(url, json=[json.dumps(data)])
+    record = {"http_status_code": resp.status, "body": await resp.text()}
+    if callback:
+        await callback(record)
+
+
+async def serve_and_predict(
+    server: svc.Server,
+    tasks: Callable[..., List[Coroutine]],
+    irises: pl.DataFrame,
+    response_by_id: Dict[str, Dict],
+):
+    data = first(list(irises.iter_rows(named=True)))
+    async with aiohttp.ClientSession() as session, asyncio.TaskGroup() as server_tg:
+        server_tg.create_task(server.serve())
+        async with asyncio.TaskGroup() as inner_tg:
+            [inner_tg.create_task(t) for t in tasks(session=session, data=data)]
+
+        server_tg.create_task(server.stop())

--- a/py-redesmyn/tests/fixtures/common.py
+++ b/py-redesmyn/tests/fixtures/common.py
@@ -1,0 +1,8 @@
+import polars as pl
+import pytest
+from tests.common import DIR_PYREDESMYN
+
+
+@pytest.fixture()
+def irises() -> pl.DataFrame:
+    return pl.read_csv(DIR_PYREDESMYN / "examples/iris/data/iris.csv")

--- a/py-redesmyn/tests/test_server.py
+++ b/py-redesmyn/tests/test_server.py
@@ -1,0 +1,77 @@
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Callable, Coroutine, Dict, List, Optional
+from unittest import mock
+
+import aiohttp
+import mlflow
+import polars as pl
+import pytest
+from more_itertools import first
+from redesmyn import artifacts as afs
+from redesmyn import service as svc
+from sklearn.utils.discovery import itemgetter
+
+from tests.common import DIR_PYREDESMYN, DIR_TESTS, request_prediction, serve_and_predict
+from tests.fixtures.common import irises
+from tests.fixtures.iris_model import (
+    Input,
+    Output,
+    SepalLengthPredictor,
+    SepalLengthPredictorSpec,
+    get_handle,
+)
+
+
+def test_handles_invalid_cache(irises: pl.DataFrame):
+    @svc.endpoint(
+        path="/invalid/predictions/{run_id}/{model_id}",
+        batch_max_delay_ms=10,
+        batch_max_size=64,
+        cache_config=afs.CacheConfig(
+            client=afs.FsClient(
+                base_path=Path("/this/path/is/not/valid"),
+                path_template="/{run_id}/{model_id}/artifacts/model",
+            ),
+            load_model=lambda *args: SepalLengthPredictor(*args),
+            spec=SepalLengthPredictorSpec,
+        ),
+    )
+    def handle_with_broken_cache(
+        model: SepalLengthPredictor, df: Input.DataFrame
+    ) -> Output.DataFrame:
+        return model.include_predictions(records_df=df)
+
+    server = svc.Server()
+    # Register both broken and working handlers
+    server.register(handle_with_broken_cache)
+    server.register(get_handle())
+
+    response_by_id = {}
+
+    def tasks(session: aiohttp.ClientSession, data: Dict) -> List[Coroutine]:
+        async def callback(record: Dict, req_id: int):
+            record["request_id"] = req_id
+            response_by_id[req_id] = record
+
+        return [
+            request_prediction(
+                url="http://localhost:8080/predictions/903683212157180428/000449a650df4e36844626e647d15664",
+                session=session,
+                data=data,
+                callback=lambda record: callback(record=record, req_id=i),
+            )
+            for i in range(10)
+        ]
+
+    coro = serve_and_predict(server=server, tasks=tasks, irises=irises, response_by_id=response_by_id)
+    asyncio.run(coro)
+    print(response_by_id)
+    assert all(r["http_status_code"] == 200 for r in response_by_id.values())
+    assert all(
+        all(type(pred) == float for pred in body["predictions"])
+        for body in (json.loads(r["body"]) for r in response_by_id.values())
+    )


### PR DESCRIPTION
## What

https://github.com/davidagold/redesmyn/issues/64 was actually filed under the mistaken conclusion that the absence of log output indicated a non-functional server when in actuality it was due simply to failing to set `RUST_LOG=info`. However, we've still included a test to ensure such failures do not occur. 