### PR TITLE
rn/gpui/refactor live updates

### DIFF
--- a/rust/crates/redesmyn_control_plane/src/command.rs
+++ b/rust/crates/redesmyn_control_plane/src/command.rs
@@ -40,6 +40,9 @@ struct CommandUpdateEventPayload {
     command_id: CommandId,
     update_id: CommandUpdateId,
     state: String,
+    kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    target_task_id: Option<TaskId>,
     message: Option<String>,
 }
 
@@ -431,6 +434,8 @@ impl Commands {
             command_id: command.command_id,
             update_id: update.update_id,
             state: update.state.as_str().to_string(),
+            kind: command.kind.clone(),
+            target_task_id: command.target_task_id,
             message: update.message.clone(),
         };
 

--- a/rust/crates/redesmyn_desktop/src/root_view.rs
+++ b/rust/crates/redesmyn_desktop/src/root_view.rs
@@ -1,4 +1,5 @@
 mod command_palette_overlay;
+mod live_updates;
 mod settings_dialog;
 
 use std::sync::Arc;
@@ -13,8 +14,6 @@ use tokio::sync::{mpsc, oneshot, watch};
 use redesmyn_ids::EventId;
 use redesmyn_protocol::client::{ModelReasoningEffort, SessionModelSelection, SubscriptionEvent};
 use redesmyn_protocol::prelude::BUILT_IN_PRELUDE_TEMPLATE;
-use redesmyn_protocol::sync_commands::{LOCAL_SYNC_EVENT_APPLIED, LOCAL_SYNC_EVENT_FAILED};
-use redesmyn_protocol::task_events::TASK_STATE_CHANGED_EVENT;
 use redesmyn_protocol::ui_driver::{
     CaptureScreenshotResponse, ClearGraphSelectionResponse, CreateChatSessionResponse,
     MultiSelectAddNodeResponse, MultiSelectRemoveNodeResponse, SelectGraphNodeResponse,
@@ -67,6 +66,7 @@ use crate::task_filters::{
 };
 
 use self::command_palette_overlay::CommandPaletteOverlay;
+use self::live_updates::{LiveUpdateAction, LiveUpdateRouter};
 use self::settings_dialog::SettingsDialog;
 
 #[derive(Debug)]
@@ -4401,6 +4401,7 @@ struct WorkspacePaneHost {
     graph_task: Option<Task<()>>,
     graph_refresh_pending: bool,
     repo_event_subscription: Option<RepoEventLogSubscription>,
+    live_update_router: LiveUpdateRouter,
     selection_generation: u64,
     _subscriptions: Vec<Subscription>,
 }
@@ -4609,6 +4610,7 @@ impl WorkspacePaneHost {
             graph_task: None,
             graph_refresh_pending: false,
             repo_event_subscription: None,
+            live_update_router: LiveUpdateRouter::new(),
             selection_generation: 0,
             _subscriptions: subscriptions,
         }
@@ -5266,6 +5268,44 @@ impl WorkspacePaneHost {
         cx.notify();
     }
 
+    fn on_repo_subscription_event(&mut self, event: SubscriptionEvent, cx: &mut Context<Self>) {
+        for action in self.live_update_router.route_subscription_event(&event) {
+            self.apply_live_update_action(action, cx);
+        }
+    }
+
+    fn apply_live_update_action(&mut self, action: LiveUpdateAction, cx: &mut Context<Self>) {
+        match action {
+            LiveUpdateAction::RefreshGraph(_) => self.refresh_graph(cx),
+            LiveUpdateAction::TaskStateChanged(update) => {
+                let changed = self.graph_view.update(cx, |view, cx| {
+                    view.apply_task_state_update(update.task_id, update.state, cx)
+                });
+                if changed {
+                    self.ui_updates.bump();
+                    cx.notify();
+                }
+            }
+            LiveUpdateAction::CommandStateChanged(update) => {
+                let changed = self.graph_view.update(cx, |view, cx| {
+                    view.apply_command_state_update(
+                        update.command_id,
+                        update.target_task_id,
+                        update.kind.as_deref(),
+                        update.state,
+                        update.message.as_deref(),
+                        update.updated_at,
+                        cx,
+                    )
+                });
+                if changed {
+                    self.ui_updates.bump();
+                    cx.notify();
+                }
+            }
+        }
+    }
+
     fn ensure_repo_event_subscription(
         &mut self,
         scope: RepoScope,
@@ -5317,38 +5357,15 @@ impl WorkspacePaneHost {
                             let Some(event) = maybe_event else {
                                 break;
                             };
-                            match event {
-                                SubscriptionEvent::EventLog(event) => {
-                                    if event.event_type != LOCAL_SYNC_EVENT_APPLIED
-                                        && event.event_type != LOCAL_SYNC_EVENT_FAILED
-                                        && event.event_type != TASK_STATE_CHANGED_EVENT
-                                    {
-                                        continue;
-                                    }
-
-                                    let _ = cx.update(|cx| {
-                                        if let Some(entity) = weak.upgrade() {
-                                            entity.update(cx, |this, cx| {
-                                                if this.selection_generation == subscription_generation {
-                                                    this.refresh_graph(cx);
-                                                }
-                                            });
+                            let _ = cx.update(|cx| {
+                                if let Some(entity) = weak.upgrade() {
+                                    entity.update(cx, |this, cx| {
+                                        if this.selection_generation == subscription_generation {
+                                            this.on_repo_subscription_event(event, cx);
                                         }
                                     });
                                 }
-                                SubscriptionEvent::Error(_) => {
-                                    let _ = cx.update(|cx| {
-                                        if let Some(entity) = weak.upgrade() {
-                                            entity.update(cx, |this, cx| {
-                                                if this.selection_generation == subscription_generation {
-                                                    this.refresh_graph(cx);
-                                                }
-                                            });
-                                        }
-                                    });
-                                }
-                                _ => {}
-                            }
+                            });
                         }
                     }
                 }

--- a/rust/crates/redesmyn_desktop/src/root_view/live_updates.rs
+++ b/rust/crates/redesmyn_desktop/src/root_view/live_updates.rs
@@ -1,0 +1,243 @@
+use redesmyn_ids::{CommandId, TaskId};
+use redesmyn_protocol::Timestamp;
+use redesmyn_protocol::client::{CommandState, EventLogEvent, SubscriptionEvent, TaskState};
+use redesmyn_protocol::sync_commands::{LOCAL_SYNC_EVENT_APPLIED, LOCAL_SYNC_EVENT_FAILED};
+use redesmyn_protocol::task_events::TASK_STATE_CHANGED_EVENT;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphRefreshReason {
+    SyncApplied,
+    SyncFailed,
+    TaskStatePayloadInvalid,
+    CommandPayloadInvalid,
+    SubscriptionError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TaskStateUpdate {
+    pub task_id: TaskId,
+    pub state: TaskState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandStateUpdate {
+    pub command_id: CommandId,
+    pub target_task_id: Option<TaskId>,
+    pub kind: Option<String>,
+    pub state: CommandState,
+    pub message: Option<String>,
+    pub updated_at: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LiveUpdateAction {
+    RefreshGraph(GraphRefreshReason),
+    TaskStateChanged(TaskStateUpdate),
+    CommandStateChanged(CommandStateUpdate),
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LiveUpdateRouter;
+
+impl LiveUpdateRouter {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    #[must_use]
+    pub fn route_subscription_event(&self, event: &SubscriptionEvent) -> Vec<LiveUpdateAction> {
+        match event {
+            SubscriptionEvent::EventLog(event) => self.route_event_log(event),
+            SubscriptionEvent::Error(_) => {
+                vec![LiveUpdateAction::RefreshGraph(
+                    GraphRefreshReason::SubscriptionError,
+                )]
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn route_event_log(&self, event: &EventLogEvent) -> Vec<LiveUpdateAction> {
+        if event.event_type == LOCAL_SYNC_EVENT_APPLIED {
+            return vec![LiveUpdateAction::RefreshGraph(
+                GraphRefreshReason::SyncApplied,
+            )];
+        }
+        if event.event_type == LOCAL_SYNC_EVENT_FAILED {
+            return vec![LiveUpdateAction::RefreshGraph(
+                GraphRefreshReason::SyncFailed,
+            )];
+        }
+        if event.event_type == TASK_STATE_CHANGED_EVENT {
+            return self.route_task_state_event(event);
+        }
+        if event.event_type.starts_with("command.") {
+            return self.route_command_state_event(event);
+        }
+        Vec::new()
+    }
+
+    fn route_task_state_event(&self, event: &EventLogEvent) -> Vec<LiveUpdateAction> {
+        #[derive(serde::Deserialize)]
+        struct TaskStateChangedPayload {
+            task_id: TaskId,
+            state: TaskState,
+        }
+
+        match serde_json::from_slice::<TaskStateChangedPayload>(&event.json_payload) {
+            Ok(payload) => vec![LiveUpdateAction::TaskStateChanged(TaskStateUpdate {
+                task_id: payload.task_id,
+                state: payload.state,
+            })],
+            Err(_) => vec![LiveUpdateAction::RefreshGraph(
+                GraphRefreshReason::TaskStatePayloadInvalid,
+            )],
+        }
+    }
+
+    fn route_command_state_event(&self, event: &EventLogEvent) -> Vec<LiveUpdateAction> {
+        #[derive(serde::Deserialize)]
+        struct CommandUpdatePayload {
+            command_id: CommandId,
+            #[serde(default)]
+            state: Option<String>,
+            #[serde(default)]
+            kind: Option<String>,
+            #[serde(default)]
+            target_task_id: Option<TaskId>,
+            #[serde(default)]
+            message: Option<String>,
+        }
+
+        let Ok(payload) = serde_json::from_slice::<CommandUpdatePayload>(&event.json_payload)
+        else {
+            return vec![LiveUpdateAction::RefreshGraph(
+                GraphRefreshReason::CommandPayloadInvalid,
+            )];
+        };
+
+        let state = payload
+            .state
+            .as_deref()
+            .and_then(parse_command_state)
+            .or_else(|| {
+                event
+                    .event_type
+                    .strip_prefix("command.")
+                    .and_then(parse_command_state)
+            });
+        let Some(state) = state else {
+            return vec![LiveUpdateAction::RefreshGraph(
+                GraphRefreshReason::CommandPayloadInvalid,
+            )];
+        };
+
+        vec![LiveUpdateAction::CommandStateChanged(CommandStateUpdate {
+            command_id: payload.command_id,
+            target_task_id: payload.target_task_id,
+            kind: payload.kind,
+            state,
+            message: payload.message,
+            updated_at: event.occurred_at,
+        })]
+    }
+}
+
+fn parse_command_state(value: &str) -> Option<CommandState> {
+    match value {
+        "unknown" => Some(CommandState::Unknown),
+        "queued" => Some(CommandState::Queued),
+        "accepted" => Some(CommandState::Accepted),
+        "running" => Some(CommandState::Running),
+        "blocked" => Some(CommandState::Blocked),
+        "resumable" => Some(CommandState::Resumable),
+        "succeeded" => Some(CommandState::Succeeded),
+        "failed" => Some(CommandState::Failed),
+        "canceled" => Some(CommandState::Canceled),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GraphRefreshReason, LiveUpdateAction, LiveUpdateRouter, parse_command_state};
+    use redesmyn_ids::{CommandId, EventId, TaskId};
+    use redesmyn_protocol::Timestamp;
+    use redesmyn_protocol::client::{CommandState, EventLogEvent, SubscriptionEvent, TaskState};
+    use redesmyn_protocol::task_events::TASK_STATE_CHANGED_EVENT;
+
+    #[test]
+    fn parses_command_states() {
+        assert_eq!(parse_command_state("running"), Some(CommandState::Running));
+        assert_eq!(parse_command_state("bad-state"), None);
+    }
+
+    #[test]
+    fn routes_task_state_changed_event() {
+        let router = LiveUpdateRouter::new();
+        let event = EventLogEvent {
+            event_id: EventId::from_bytes([1; 16]),
+            occurred_at: Timestamp::from_unix_millis(0).expect("timestamp"),
+            event_type: TASK_STATE_CHANGED_EVENT.to_string(),
+            json_payload: serde_json::to_vec(&serde_json::json!({
+                "task_id": TaskId::from_bytes([2; 16]),
+                "state": "in_progress"
+            }))
+            .expect("json"),
+        };
+        let updates = router.route_subscription_event(&SubscriptionEvent::EventLog(event));
+        assert!(matches!(
+            updates.as_slice(),
+            [LiveUpdateAction::TaskStateChanged(update)]
+            if update.state == TaskState::InProgress
+        ));
+    }
+
+    #[test]
+    fn routes_command_state_event() {
+        let router = LiveUpdateRouter::new();
+        let command_id = CommandId::from_bytes([3; 16]);
+        let task_id = TaskId::from_bytes([4; 16]);
+        let event = EventLogEvent {
+            event_id: EventId::from_bytes([5; 16]),
+            occurred_at: Timestamp::from_unix_millis(1).expect("timestamp"),
+            event_type: "command.running".to_string(),
+            json_payload: serde_json::to_vec(&serde_json::json!({
+                "command_id": command_id,
+                "state": "running",
+                "kind": "task.agent.start",
+                "target_task_id": task_id,
+                "message": "starting"
+            }))
+            .expect("json"),
+        };
+
+        let updates = router.route_subscription_event(&SubscriptionEvent::EventLog(event));
+        assert!(matches!(
+            updates.as_slice(),
+            [LiveUpdateAction::CommandStateChanged(update)]
+            if update.command_id == command_id
+                && update.target_task_id == Some(task_id)
+                && update.state == CommandState::Running
+        ));
+    }
+
+    #[test]
+    fn falls_back_to_refresh_on_invalid_command_payload() {
+        let router = LiveUpdateRouter::new();
+        let event = EventLogEvent {
+            event_id: EventId::from_bytes([6; 16]),
+            occurred_at: Timestamp::from_unix_millis(2).expect("timestamp"),
+            event_type: "command.failed".to_string(),
+            json_payload: br#"{"command_id":"not-a-command-id"}"#.to_vec(),
+        };
+        let updates = router.route_subscription_event(&SubscriptionEvent::EventLog(event));
+        assert_eq!(
+            updates,
+            vec![LiveUpdateAction::RefreshGraph(
+                GraphRefreshReason::CommandPayloadInvalid
+            )]
+        );
+    }
+}

--- a/rust/crates/redesmyn_ui_graph/src/scene.rs
+++ b/rust/crates/redesmyn_ui_graph/src/scene.rs
@@ -480,6 +480,87 @@ impl GraphScene {
         self.nodes.get(&id)
     }
 
+    pub fn apply_task_state_update(&mut self, task_id: TaskId, state: TaskState) -> bool {
+        let Some(node) = self.nodes.get_mut(&GraphNodeId::Task(task_id)) else {
+            return false;
+        };
+        if node.state == state {
+            return false;
+        }
+        node.state = state;
+        true
+    }
+
+    pub fn apply_command_state_update(
+        &mut self,
+        command_id: CommandId,
+        target_task_id: Option<TaskId>,
+        kind: Option<&str>,
+        state: CommandState,
+        message: Option<&str>,
+        updated_at: Timestamp,
+    ) -> bool {
+        let node_id = target_task_id.map(GraphNodeId::Task).or_else(|| {
+            self.nodes.iter().find_map(|(node_id, node)| {
+                matches!(node_id, GraphNodeId::Task(_))
+                    .then_some(node.latest_command.as_ref())
+                    .flatten()
+                    .and_then(|latest| (latest.command_id == command_id).then_some(*node_id))
+            })
+        });
+        let Some(node_id) = node_id else {
+            return false;
+        };
+        let Some(node) = self.nodes.get_mut(&node_id) else {
+            return false;
+        };
+
+        let should_apply_to_latest = match node.latest_command.as_ref() {
+            Some(latest) if latest.command_id != command_id => updated_at >= latest.updated_at,
+            _ => true,
+        };
+
+        let mut changed = false;
+        if should_apply_to_latest {
+            let message = message
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(|value| SharedString::new(value.to_string()));
+            let kind = kind
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(|value| SharedString::new(value.to_string()))
+                .or_else(|| {
+                    node.latest_command
+                        .as_ref()
+                        .filter(|latest| latest.command_id == command_id)
+                        .map(|latest| latest.kind.clone())
+                })
+                .unwrap_or_else(|| SharedString::new("command".to_string()));
+            let next = TaskCommandSummary {
+                command_id,
+                kind,
+                state,
+                updated_at,
+                last_message: message,
+            };
+            if node.latest_command.as_ref() != Some(&next) {
+                node.latest_command = Some(next);
+                changed = true;
+            }
+        }
+
+        if should_apply_to_latest {
+            let next_status = agent_status_from_command_state(state);
+            if node.agent_status != next_status {
+                node.agent_status = next_status;
+                changed = true;
+            }
+        }
+
+        changed
+    }
+
     #[must_use]
     pub fn selection(&self) -> &GraphSelection {
         &self.selection
@@ -1151,24 +1232,12 @@ fn agent_status_by_task_id(
         }
     }
 
-    fn from_command_state(state: CommandState) -> AgentStatus {
-        match state {
-            CommandState::Queued | CommandState::Running | CommandState::Accepted => {
-                AgentStatus::Running
-            }
-            CommandState::Blocked | CommandState::Resumable => AgentStatus::Blocked,
-            CommandState::Failed => AgentStatus::Error,
-            CommandState::Succeeded | CommandState::Canceled => AgentStatus::Stopped,
-            CommandState::Unknown => AgentStatus::Unknown,
-        }
-    }
-
     let mut out: BTreeMap<TaskId, AgentStatus> = BTreeMap::new();
     for summary in &graph.command_summaries {
         let Some(task_id) = summary.target_task_id else {
             continue;
         };
-        let status = from_command_state(summary.state);
+        let status = agent_status_from_command_state(summary.state);
         out.entry(task_id)
             .and_modify(|existing| {
                 if priority(status) > priority(*existing) {
@@ -1178,6 +1247,18 @@ fn agent_status_by_task_id(
             .or_insert(status);
     }
     out
+}
+
+fn agent_status_from_command_state(state: CommandState) -> AgentStatus {
+    match state {
+        CommandState::Queued | CommandState::Running | CommandState::Accepted => {
+            AgentStatus::Running
+        }
+        CommandState::Blocked | CommandState::Resumable => AgentStatus::Blocked,
+        CommandState::Failed => AgentStatus::Error,
+        CommandState::Succeeded | CommandState::Canceled => AgentStatus::Stopped,
+        CommandState::Unknown => AgentStatus::Unknown,
+    }
 }
 
 fn latest_session_by_task_id(
@@ -1606,5 +1687,51 @@ mod tests {
         let bounds = scene.layout_bounds();
         assert!(bounds.size.width > 0);
         assert!(bounds.size.height > 0);
+    }
+
+    #[test]
+    fn apply_task_state_update_mutates_target_node() {
+        let task_id = TaskId::from_bytes([9; 16]);
+        let mut scene = GraphScene::empty_demo();
+        scene.insert_demo_node(GraphNodeId::Task(task_id));
+
+        assert!(scene.apply_task_state_update(task_id, TaskState::InProgress));
+        assert_eq!(
+            scene
+                .node(GraphNodeId::Task(task_id))
+                .map(|node| node.state),
+            Some(TaskState::InProgress)
+        );
+        assert!(!scene.apply_task_state_update(task_id, TaskState::InProgress));
+    }
+
+    #[test]
+    fn apply_command_state_update_sets_agent_status_and_latest_command() {
+        let task_id = TaskId::from_bytes([10; 16]);
+        let command_id = CommandId::from_bytes([11; 16]);
+        let mut scene = GraphScene::empty_demo();
+        scene.insert_demo_node(GraphNodeId::Task(task_id));
+
+        let updated_at = Timestamp::from_unix_millis(1).expect("timestamp");
+        assert!(scene.apply_command_state_update(
+            command_id,
+            Some(task_id),
+            Some("task.agent.start"),
+            CommandState::Running,
+            Some("starting"),
+            updated_at,
+        ));
+
+        let node = scene
+            .node(GraphNodeId::Task(task_id))
+            .expect("task node should exist");
+        assert_eq!(node.agent_status, AgentStatus::Running);
+        let latest = node.latest_command.as_ref().expect("latest command");
+        assert_eq!(latest.command_id, command_id);
+        assert_eq!(latest.state, CommandState::Running);
+        assert_eq!(
+            latest.last_message.as_ref().map(|message| message.as_ref()),
+            Some("starting")
+        );
     }
 }

--- a/rust/crates/redesmyn_ui_graph/src/view.rs
+++ b/rust/crates/redesmyn_ui_graph/src/view.rs
@@ -40,14 +40,17 @@ use crate::scene::{AgentStatus, GraphEdgeId, GraphNodeId, GraphScene, TrunkMarkK
 
 use redesmyn_markdown::{MarkdownParseOptions, parse_markdown};
 use redesmyn_protocol::client::{
-    AgentKind, AgentMessageConflictAction, MergeReadiness, RequestPayload, ResponseResult,
-    RestartAgentRequest, SessionModelSelection, StartAgentRequest, StopAgentRequest, TaskState,
+    AgentKind, AgentMessageConflictAction, CommandState, MergeReadiness, RequestPayload,
+    ResponseResult, RestartAgentRequest, SessionModelSelection, StartAgentRequest,
+    StopAgentRequest, TaskState,
 };
 use redesmyn_protocol::ui_driver::{
     UiGraphCameraState, UiGraphEdgeId as UiDriverGraphEdgeId, UiGraphLoadState,
     UiGraphNodeId as UiDriverGraphNodeId, UiGraphState,
 };
-use redesmyn_protocol::{CodexApprovalPolicy, CodexSandboxPolicy, ProtocolEnvelope, RepoScope};
+use redesmyn_protocol::{
+    CodexApprovalPolicy, CodexSandboxPolicy, ProtocolEnvelope, RepoScope, Timestamp,
+};
 use redesmyn_ui_session::{SessionView, SessionViewEvent, TaskSessionOperation};
 
 /// Key context used for graph-only keyboard shortcuts (e.g., task filter toggle).
@@ -531,6 +534,70 @@ impl GraphView {
 
         self.update_selection_bar_target(cx);
         cx.notify();
+    }
+
+    pub fn apply_task_state_update(
+        &mut self,
+        task_id: TaskId,
+        state: TaskState,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        self.apply_runtime_scene_update(cx, |scene| scene.apply_task_state_update(task_id, state))
+    }
+
+    pub fn apply_command_state_update(
+        &mut self,
+        command_id: CommandId,
+        target_task_id: Option<TaskId>,
+        kind: Option<&str>,
+        state: CommandState,
+        message: Option<&str>,
+        updated_at: Timestamp,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        self.apply_runtime_scene_update(cx, |scene| {
+            scene.apply_command_state_update(
+                command_id,
+                target_task_id,
+                kind,
+                state,
+                message,
+                updated_at,
+            )
+        })
+    }
+
+    fn apply_runtime_scene_update<F>(&mut self, cx: &mut Context<Self>, mut apply: F) -> bool
+    where
+        F: FnMut(&mut GraphScene) -> bool,
+    {
+        let previous_selected = self.scene.selection().selected_node;
+        let changed = if let Some(full) = self.full_scene.as_mut() {
+            let changed_full = apply(full);
+            if changed_full {
+                self.scene = full.filtered_pruned(&self.task_filters);
+            }
+            changed_full
+        } else {
+            apply(&mut self.scene)
+        };
+
+        if !changed {
+            return false;
+        }
+
+        self.edge_label_cache.borrow_mut().clear();
+
+        let next_selected = self.scene.selection().selected_node;
+        if previous_selected != next_selected {
+            self.reset_expanded_card_state();
+            self.sync_task_session_view(next_selected, cx);
+            self.sync_task_description(next_selected, cx);
+        }
+
+        self.update_selection_bar_target(cx);
+        cx.notify();
+        true
     }
 
     fn visual_selected_node(&self) -> Option<GraphNodeId> {


### PR DESCRIPTION
- **ui(session-view): debounce list reset on resize**
- **ui(session-view): hide timeline scrollbar during resize**
- **ui(session-view): reduce resize debounce to 50ms**
- **rn(ui): polish cascading menu styling**
- **rn(ui): unify cascading menu surface styling**
- **rn(ui-driver): dedupe smoke harness**
- **rn(ui): enforce single open cascading menu**
- **rn(ui): share cascading menu option indicators**
- **gpui: add T-83 task doc**
- **gpui: align T-83 branch name**
- **gpui: fix FK errors persisting daemon session events**
- **gpui: load full-text messages from blob-key artifacts**
- **docs(gpui): clarify repo instance exclusivity vs leases**
- **redesmyn_git: add GitBackend abstraction and CLI backend**
- **redesmyn_daemon: add swappable git backend**
- **redesmyn_git: normalize paths in worktree list test**
- **redesmyn_git: harden worktree args against option injection**
- **redesmyn_git: harden worktree add arg separation**
- **redesmyn_git: tighten revision validation and cancel handling**
- **gpui: add codex model defaults**
- **gpui: polish codex model selectors and menu behavior**
- **refactor(gpui): remove agent interface mode**
- **refactor(agent): remove interactive message command path**
- **fix(ui-session): stabilize timeline invalidation and artifact logging**
- **style: normalize formatting in touched crates**
- **gpui: fix composer shortcut hints and menu left-nav**
- **gpui: focus selector menus when opened by shortcut**
- **docs(director-v0): parallelize task sequencing after T-1**
- **feat(rn): sync local docs via control plane and live-refresh graph**
- **feat(session): support pasted image attachments in composer**
- **fix(control-plane): fail start-agent when daemon dispatch fails**
- **Polish expanded task card details and add slug-based UI-driver selection**
- **rn ui-driver: add collapse-left-pane mode for graph smoke**
- **Polish expanded task card details layout and content**
- **Tighten expanded card session pane top spacing**
- **Refine expanded card actions and branch wrapping**
- **Make ui-driver graph smoke wait on concrete selection state**
- **ui(split-pane): hide divider seam when left pane collapsed**
- **ui(split-pane): fully hide collapsed primary pane**
- **feat(task-session): apply configured model defaults on start**
- **refactor(ui): reduce duplicate model-default copy and gate selectors**
- **docs: Include gpui T-84, T-85**
- **ui: remove manual session refresh affordances and stabilize task-scoped composer defaults**
- **feat(task-session): ensure task worktrees and auto-start prelude**
- **fix(session-model): preserve durable selection on stopped session resume**
- **ui: disable task filter shortcut while composer is focused**
- **ui: scope graph filter shortcut to graph focus**
- **config: shorten default control-plane socket path on unix**
- **ui(graph): keep shortcut focus on graph clicks**
- **ui(session): scope composer menus and restore shortcut hints**
- **ui: tie shortcut hints to focused shortcut scopes**
- **ui(session): gate shortcuts on composer descendant focus**
- **ui: stabilize graph filter shortcut focus lifecycle**
- **ui(session): isolate settings menus per session view owner**
- **docs(director-v0): align controller-driven director model**
- **fix(desktop): open task session settings submenu inward**
- **fix(control-plane): keep client UDS server alive on accept errors**
- **docs(epics): add ui-driver-v1 epic and task dependency map**
- **feat(rn): add task start command via control plane**
- **feat(task-start): apply defaults + mark tasks in progress**
- **feat(gpui): unify task prelude defaults and worktree paths**
- **refactor(gpui): route repo live updates through typed deltas**
